### PR TITLE
Removed dynamic allocation and simplier initialization syntax for Conf.

### DIFF
--- a/Test3.cpp
+++ b/Test3.cpp
@@ -8,6 +8,7 @@ using namespace std::literals::string_literals;
 
 using namespace zia::apipp;
 /// TODO:  Helpers to set values in ConfElem constructor.
+/// TODO:  Add set version with copyable value arguments.
 void test3() {
     auto conf = ConfElem()
         .set(ConfMap())

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -7,31 +7,44 @@
 using namespace std::literals::string_literals;
 
 using namespace zia::apipp;
-
+/// TODO:  Helpers to set values in ConfElem constructor.
 void test3() {
-    auto conf = (new ConfElem())
-            ->set(new ConfMap)
-            ->set_at("string_test", (new ConfElem())->set("first_value"s))
-            ->set_at("integer_test", (new ConfElem())->set(42))
-            ->set_at("double_test", (new ConfElem())->set(42.42))
-            ->set_at("nested_map_test", (new ConfElem())
-                    ->set(new ConfMap())
-                    ->set_at("op", (new ConfElem())->set(1)))
-            ->set_at("array_test", (new ConfElem())
-                    ->set(new ConfArray())
-                    ->push((new ConfElem())->set(true))
-                    ->push((new ConfElem())->set(false)));
+    auto conf = ConfElem()
+        .set(ConfMap())
+        .set_at("string_test", ConfElem().set("first_value"s))
+        .set_at("integer_test", ConfElem().set(42))
+        .set_at("double_test", ConfElem().set(42.42))
+        .set_at("nested_map_test", ConfElem()
+            .set(ConfMap())
+            .set_at("op", ConfElem().set(1)))
+        .set_at("array_test",
+                ConfElem().set(ConfArray())
+                .push(ConfElem().set(true))
+                .push(ConfElem().set(false)));
 
-    std::cout << conf->get_at("string_test")->get<std::string>() << std::endl;
-    std::cout << conf->get_at("integer_test")->get<int>() << std::endl;
-    std::cout << conf->get_at("integer_test")->get<long long>() << std::endl;
-    std::cout << conf->get_at("double_test")->get<double>() << std::endl;
-    std::cout << conf->get_at("double_test")->get<float>() << std::endl;
+    std::cout << conf.get_at("string_test").get<std::string>() << std::endl;
+    std::cout << conf.get_at("integer_test").get<int>() << std::endl;
+    std::cout << conf.get_at("integer_test").get<long long>() << std::endl;
+    std::cout << conf.get_at("double_test").get<double>() << std::endl;
+    std::cout << conf.get_at("double_test").get<float>() << std::endl;
 
-    std::cout << conf->get_at("nested_map_test")->get_at("op")->get<int>() << std::endl;
+    std::cout << conf.get_at("nested_map_test").get_at("op").get<int>() << std::endl;
 
-    std::cout << conf->get_at("array_test")->get_at(0)->get<bool>() << std::endl;
-    std::cout << conf->get_at("array_test")->get_at(1)->get<bool>() << std::endl;
+    std::cout << conf.get_at("array_test").get_at(0).get<bool>() << std::endl;
+    std::cout << conf.get_at("array_test").get_at(1).get<bool>() << std::endl;
 
-    delete conf;
+    /// Really ugly syntax...
+    /// std::cout << (*conf)["array_test"]->operator[](0)->get<bool>() << std::endl;
+    std::cout << conf["array_test"][0].get<bool>() << std::endl;
+
+    /// Test with copy
+    ConfElem conf3 = ConfElem().set(ConfArray());
+
+    conf3.push(ConfElem().set("toto"s));
+    conf3.push(ConfElem().set("titi"s));
+    ConfElem conf2 = conf.set(ConfMap()).set_at("data", conf3);
+
+    std::cout << conf2.get_at("data").get_at(0).get<std::string>() << std::endl;
+    std::cout << conf2.get_at("data").get_at(1).get<std::string>() << std::endl;
+
 }

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -6,25 +6,11 @@
 
 namespace zia::apipp {
 
-    apipp::ConfMap::~ConfMap() {
-        for (auto &item : elems) {
-            delete item.second;
-        }
-    }
+    apipp::ConfMap::~ConfMap() = default;
 
-    ConfArray::~ConfArray() {
-        for (auto &item : elems) {
-            delete item;
-        }
-    }
+    ConfArray::~ConfArray() = default;
 
-    ConfElem::~ConfElem() {
-        if (type == Map) {
-            delete std::get<ConfMap *>(value);
-        } else if (type == Array) {
-            delete std::get<ConfArray *>(value);
-        }
-    }
+    ConfElem::~ConfElem() = default;
 
   /**
   * Set a ConfMap value.
@@ -32,22 +18,37 @@ namespace zia::apipp {
   * @param val
   */
   template<>
-  ConfElem *ConfElem::set<ConfMap *>(ConfMap *&&val) {
+  ConfElem &ConfElem::set<ConfMap>(ConfMap &&val) & {
       type = Map;
-      value = std::forward<ConfMap *>(val);
-      return this;
+      value = std::make_unique<ConfMap>(std::move(val));
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<ConfMap>(ConfMap &&val) && {
+      type = Map;
+      value = std::make_unique<ConfMap>(std::move(val));
+      return std::move(*this);
   }
 
   /**
-   * Set a ConfArray value.
-   *
-   * @param val
-   */
+  * Set a ConfArray value.
+  *
+  * @param val
+  */
+
   template<>
-  ConfElem *ConfElem::set<ConfArray *>(ConfArray *&&val) {
+  ConfElem &ConfElem::set<ConfArray>(ConfArray &&val) & {
       type = Array;
-      value = std::forward<ConfArray *>(val);
-      return this;
+      value = std::make_unique<ConfArray>(std::move(val));
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<ConfArray>(ConfArray &&val) && {
+      type = Array;
+      value = std::make_unique<ConfArray>(std::move(val));
+      return std::move(*this);
   }
 
   /**
@@ -58,11 +59,19 @@ namespace zia::apipp {
    * @bug when using like : conf.set("toto"). Possible fix: using the string_literal suffixe to use std::string instead of char *.
    * @param val
    */
+
   template<>
-  ConfElem *ConfElem::set<char *>(char *&&val) {
+  ConfElem &ConfElem::set<char *>(char *&&val) & {
       type = String;
-      value = std::string(std::forward<char *>(val));
-      return this;
+      value = std::string(val);
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<char *>(char *&&val) && {
+      type = String;
+      value = std::string(val);
+      return std::move(*this);
   }
 
   /**
@@ -71,10 +80,17 @@ namespace zia::apipp {
    * @param val
    */
   template<>
-  ConfElem *ConfElem::set<std::string>(std::string &&val) {
+  ConfElem &ConfElem::set<std::string>(std::string &&val) & {
       type = String;
-      value = std::forward<std::string>(val);
-      return this;
+      value = std::move(val);
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<std::string>(std::string &&val) && {
+      type = String;
+      value = std::move(val);
+      return std::move(*this);
   }
 
   /**
@@ -84,10 +100,17 @@ namespace zia::apipp {
    * @param val
    */
   template<>
-  ConfElem *ConfElem::set<int>(int &&val) {
+  ConfElem &ConfElem::set<int>(int &&val) & {
       type = Integer;
-      value = static_cast<long long>(std::forward<int>(val));
-      return this;
+      value = static_cast<long long>(val);
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<int>(int &&val) && {
+      type = Integer;
+      value = static_cast<long long>(val);
+      return std::move(*this);
   }
 
   /**
@@ -96,23 +119,38 @@ namespace zia::apipp {
    * @param val
    */
   template<>
-  ConfElem *ConfElem::set<long long>(long long &&val) {
+  ConfElem &ConfElem::set<long long>(long long &&val) & {
       type = Integer;
-      value = std::forward<long long>(val);
-      return this;
+      value = val;
+      return *this;
   }
 
-  /**
+    template<>
+    ConfElem &&ConfElem::set<long long>(long long &&val) && {
+        type = Integer;
+        value = val;
+        return std::move(*this);
+    }
+
+
+    /**
    * Set a double value.
    * Alias for double.
    *
    * @param val
    */
+    template<>
+    ConfElem &ConfElem::set<float>(float &&val) & {
+        type = Integer;
+        value = static_cast<double>(val);
+        return *this;
+    }
+
   template<>
-  ConfElem *ConfElem::set<float>(float &&val) {
+  ConfElem &&ConfElem::set<float>(float &&val) && {
       type = Integer;
-      value = static_cast<double>(std::forward<float>(val));
-      return this;
+      value = static_cast<double>(val);
+      return std::move(*this);
   }
 
   /**
@@ -121,10 +159,17 @@ namespace zia::apipp {
    * @param val
    */
   template<>
-  ConfElem *ConfElem::set<double>(double &&val) {
+  ConfElem &ConfElem::set<double>(double &&val) & {
       type = Double;
-      value = std::forward<double>(val);
-      return this;
+      value = val;
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<double>(double &&val) && {
+      type = Double;
+      value = val;
+      return std::move(*this);
   }
 
   /**
@@ -133,9 +178,16 @@ namespace zia::apipp {
    * @param val
    */
   template<>
-  ConfElem *ConfElem::set<bool>(bool &&val) {
+  ConfElem &ConfElem::set<bool>(bool &&val) & {
       type = Boolean;
-      value = std::forward<bool>(val);
-      return this;
+      value = val;
+      return *this;
+  }
+
+  template<>
+  ConfElem &&ConfElem::set<bool>(bool &&val) && {
+      type = Boolean;
+      value = val;
+      return std::move(*this);
   }
 }

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -18,10 +18,10 @@ namespace zia::apipp {
         using Sptr = std::shared_ptr<ConfMap>;
 
         ConfMap() = default;
-//        ConfMap(ConfMap const&) = default;
+        ConfMap(ConfMap const&) = default;
         ConfMap(ConfMap&&) = default;
 
-  //      ConfMap& operator=(ConfMap const&) = default;
+        ConfMap& operator=(ConfMap const&) = default;
         ConfMap& operator=(ConfMap&&) = default;
 
         std::map<std::string, ConfElem> elems;
@@ -35,10 +35,10 @@ namespace zia::apipp {
         using Sptr = std::shared_ptr<ConfArray>;
 
         ConfArray() = default;
-    //    ConfArray(ConfArray const&) = default;
+        ConfArray(ConfArray const&) = default;
         ConfArray(ConfArray&&) = default;
 
-      //  ConfArray& operator=(ConfArray const&) = default;
+        ConfArray& operator=(ConfArray const&) = default;
         ConfArray& operator=(ConfArray&&) = default;
 
         std::vector<ConfElem> elems;
@@ -115,7 +115,7 @@ namespace zia::apipp {
 
         /**
          * Set the value into the std::variant.
-         *
+         *  
          * If a invalid T is passed, a error (LNK2019 on MSVC) will occur during the linking pass of the compilation.
          *
          * @tparam T
@@ -127,8 +127,8 @@ namespace zia::apipp {
         ConfElem &&set(T &&) &&;
 
         /**
-         * Push a ConfElem into the ConfArray value.
-         *
+         * Push a ConfElem into the ConfArray value. The value is moved into the array.
+         * 
          * @throw InvalidAccess if the value is not a ConfArray
          *
          * @tparam T
@@ -146,6 +146,16 @@ namespace zia::apipp {
             return *this;
         }
 
+		/**
+		* Push a ConfElem into the ConfArray value. The value is moved into the array.
+		*
+		* @throw InvalidAccess if the value is not a ConfArray
+		*
+		* @tparam T
+		* @param index
+		* @param val
+		* @return
+		*/
         ConfElem &&push(ConfElem &&val) && {
             try {
                 std::get<ConfArray::Sptr>(value)->elems.emplace_back( std::move(val) ) ;
@@ -157,13 +167,13 @@ namespace zia::apipp {
         }
 
         /**
-         * Insert a value into the ConfMap value.
+         * Insert a value into the ConfMap value. Value is moved into the map.
          *
          * @throw InvalidAccess if the value is not a ConfMap.
          *
          * @param index
          * @param val
-         * @return
+         * @return.
          */
         ConfElem &set_at(const std::string &index, ConfElem && val) & {
             try {
@@ -175,6 +185,15 @@ namespace zia::apipp {
             return *this;
         }
 
+		/**
+		* Insert a value into the ConfMap value. Value is moved into the map.
+		*
+		* @throw InvalidAccess if the value is not a ConfMap.
+		*
+		* @param index
+		* @param val
+		* @return
+		*/
         ConfElem &&set_at(const std::string &index, ConfElem && val) && {
             try {
                 std::get<ConfMap::Sptr>(value)->elems.emplace(index, std::move(val));
@@ -185,6 +204,15 @@ namespace zia::apipp {
             return std::move(*this);
         }
 
+		/**
+		* Insert a value into the ConfMap value. Value is copied into the map element.
+		*
+		* @throw InvalidAccess if the value is not a ConfMap.
+		*
+		* @param index
+		* @param val
+		* @return
+		*/
         ConfElem &set_at(const std::string &index, ConfElem const& val) & {
             try {
                 std::get<ConfMap::Sptr>(value)->elems.emplace(index, val);
@@ -195,6 +223,15 @@ namespace zia::apipp {
             return *this;
         }
 
+		/**
+		* Insert a value into the ConfMap value. Value is copied into the map element.
+		*
+		* @throw InvalidAccess if the value is not a ConfMap.
+		*
+		* @param index
+		* @param val
+		* @return
+		*/
         ConfElem &&set_at(const std::string &index, ConfElem const& val) && {
             try {
                 std::get<ConfMap::Sptr>(value)->elems.emplace(index, val);
@@ -232,6 +269,14 @@ namespace zia::apipp {
             }
         }
 
+		/**
+		* Access to an index of a constant ConfArray.
+		*
+		* @throw InvalidAccess if the value is not a ConfArray
+		*
+		* @param index
+		* @return
+		*/
         const ConfElem &operator[](const int index) const {
             try {
                 return (std::get<ConfArray::Sptr>(value))->elems.at(index);
@@ -258,6 +303,14 @@ namespace zia::apipp {
             }
         }
 
+		/**
+		* Access to an index of a ConfMap.
+		*
+		* @throw InvalidAccess if the value is not a ConfMap
+		*
+		* @param index
+		* @return
+		*/
         const ConfElem &operator[](const std::string &index) const {
             try {
                 return (std::get<ConfMap::Sptr>(value))->elems.at(index);


### PR DESCRIPTION
## Current problems

- Manual dynamic allocation is necessary to initialize configuration structures. This requires a heavier syntax for initialization and manual memory management while smart-pointers and move-semantics are here!
- Consequently, return value of methods must be pointers to comply with get/set method api of the config. For exemple:
> (new ConfArray())->set_at(new ConfMap())->set();

Could be changed with : 
> ConfArray().set_at(ConfMap()).set()

## Propositions

- Removed all dynamic allocations for values set in the map. A ConfElem now contain a shared_pointer that is constructed in-place with a move/copy constructor. ConfArray and ConfMap structures now contain values instead of pointers. Values in the containers are moved whenever it's possible.

- Removed _this_ return as pointer for better chain method call syntax. Calls are correctly overloaded when inline construction is needed.