### PR TITLE
from/to BasicConf implementation, Serialization of Conf objects and recursive visitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(sza_plus_plus
 
         Test1.cpp
         Test2.cpp
-        Test3.cpp)
+        Test3.cpp api/pp/visitor.hpp)
 
 if (WIN32)
     target_compile_options(sza_plus_plus PRIVATE /std:c++latest)

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -127,14 +127,16 @@ void test3() {
 
         zia::api::Conf confRoot { { "data", root } };
 
-        auto basicprettyfied = ConfElem::basicPrettify(root);
-        std::cout << basicprettyfied << std::endl;
-    /// Tests conversion fromBasicConfig
+        std::cout << "TEST -- To SZA ++ Config" << std::endl;
         auto wrappedConfig = Conf::fromBasicConfig(confRoot);
 
         auto prettyfied = ConfElem::prettify(wrappedConfig);
-
         std::cout << prettyfied << std::endl;
 
+        std::cout << "TEST -- From SZA ++ Config" << std::endl;
+        auto newConfig = wrappedConfig.toBasicConfig();
+
+        auto basicprettyfied = ConfElem::basicPrettify(newConfig);
+        std::cout << basicprettyfied << std::endl;
     }
 }

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "api/pp/conf.hpp"
+#include "api/pp/visitor.hpp"
 
 using namespace std::literals::string_literals;
 
@@ -99,5 +100,41 @@ void test3() {
         std::cout << conf2.get_at("data").get_at("first").get<std::string>() << std::endl;
     }
 
-//    auto conftest = ConfElem(42);
+    /// Test prettify
+    {
+        zia::api::ConfValue valueBool;
+        valueBool.v = true;
+        zia::api::ConfValue valueString;
+        valueString.v = "String Value";
+        zia::api::ConfValue valueLong;
+        valueLong.v = static_cast<long long int>(1785);
+        zia::api::ConfValue valueDouble;
+        valueDouble.v = 42.42;
+
+
+        zia::api::ConfValue valueArray;
+        valueArray.v = std::vector<zia::api::ConfValue> { valueBool, valueString, valueLong, valueDouble };
+
+        zia::api::ConfValue valueMap;
+        valueMap.v = std::map<std::string, zia::api::ConfValue> {
+            {"first", valueArray},
+            {"second", valueBool},
+            {"third", valueLong},
+            {"fourth", valueString},
+            {"fifth", valueDouble}
+        };
+        zia::api::ConfValue root = valueMap;
+
+        zia::api::Conf confRoot { { "data", root } };
+
+        auto basicprettyfied = ConfElem::basicPrettify(root);
+        std::cout << basicprettyfied << std::endl;
+    /// Tests conversion fromBasicConfig
+        auto wrappedConfig = Conf::fromBasicConfig(confRoot);
+
+        auto prettyfied = ConfElem::prettify(wrappedConfig);
+
+        std::cout << prettyfied << std::endl;
+
+    }
 }

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -132,5 +132,29 @@ void test3() {
         std::cout << "TEST -- From SZA ++ Config" << std::endl;
         auto newConfig = wrappedConfig.toBasicConfig();
         std::cout << newConfig << std::endl;
+
+        /// Visitor used to iterate over the configuration.
+        /// Use this instead of chaining "get<T>()" calls with try/catch.
+        /// The first argument is the "self" lambda. Call it to continue recursion.
+        /// TODO: visit method in Conf for easier manipulation.
+        std::cout << "TEST -- Visit of Conf element" << std::endl;
+        auto testVisitor = make_recursive_visitor<void>(
+            [](auto, std::monostate) { std::cout << "Empty" << std::endl; },
+            [](auto, std::string const&) { std::cout << "String" << std::endl; },
+            [](auto, long long int) { std::cout << "Long" << std::endl; },
+            [](auto, double) { std::cout << "Double" << std::endl;} ,
+            [](auto, bool) { std::cout << "Bool" << std::endl; },
+            [](auto recurse, ConfArray::Sptr const& array) { std::cout << "Array" << std::endl;
+                for (auto&& v : array->elems) {
+                    recurse(v->getValue());
+                }
+            },
+            [](auto recurse, ConfMap::Sptr const& map) { std::cout << "Map" << std::endl;
+            for (auto&& v : map->elems) {
+                recurse(v.second->getValue());
+            }}
+        );
+
+        std::visit(testVisitor, wrappedConfig.getValue());
     }
 }

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -87,7 +87,7 @@ void test3() {
         confArray->push(confString);
         confArray->push(ConfElem("titi"s));
 
-        auto conf2 = conf.set(ConfMap()).set_at("data", confArray);
+        auto conf2 = ConfElem().set(ConfMap()).set_at("data", confArray);
         confString->set("new_value"s);
 
         std::cout << conf2.get_at("data").get_at(0).get<std::string>() << std::endl;
@@ -105,7 +105,7 @@ void test3() {
         zia::api::ConfValue valueBool;
         valueBool.v = true;
         zia::api::ConfValue valueString;
-        valueString.v = "String Value";
+        valueString.v = "String Value"s;
         zia::api::ConfValue valueLong;
         valueLong.v = static_cast<long long int>(1785);
         zia::api::ConfValue valueDouble;
@@ -115,28 +115,22 @@ void test3() {
         zia::api::ConfValue valueArray;
         valueArray.v = std::vector<zia::api::ConfValue> { valueBool, valueString, valueLong, valueDouble };
 
-        zia::api::ConfValue valueMap;
-        valueMap.v = std::map<std::string, zia::api::ConfValue> {
+        zia::api::ConfObject valueMap;
+        valueMap = std::map<std::string, zia::api::ConfValue> {
             {"first", valueArray},
             {"second", valueBool},
             {"third", valueLong},
             {"fourth", valueString},
             {"fifth", valueDouble}
         };
-        zia::api::ConfValue root = valueMap;
-
-        zia::api::Conf confRoot { { "data", root } };
+        zia::api::Conf root = valueMap;
 
         std::cout << "TEST -- To SZA ++ Config" << std::endl;
-        auto wrappedConfig = Conf::fromBasicConfig(confRoot);
-
-        auto prettyfied = ConfElem::prettify(wrappedConfig);
-        std::cout << prettyfied << std::endl;
+        auto wrappedConfig = Conf::fromBasicConfig(root);
+        std::cout << wrappedConfig << std::endl;
 
         std::cout << "TEST -- From SZA ++ Config" << std::endl;
         auto newConfig = wrappedConfig.toBasicConfig();
-
-        auto basicprettyfied = ConfElem::basicPrettify(newConfig);
-        std::cout << basicprettyfied << std::endl;
+        std::cout << newConfig << std::endl;
     }
 }

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -2,7 +2,9 @@
 // Created by sylva on 10/02/2018.
 //
 
+#include <iomanip>
 #include "conf.hpp"
+#include "visitor.hpp"
 
 namespace zia::apipp {
 
@@ -11,4 +13,137 @@ namespace zia::apipp {
     ConfArray::~ConfArray() = default;
 
     ConfElem::~ConfElem() = default;
+
+    ConfElem ConfElem::fromBasicConfig(const zia::api::Conf &conf) {
+
+        auto jsonConfig = ConfElem(ConfMap());
+
+        auto visitor = make_recursive_visitor<ConfElem>(
+            [](auto, std::monostate) { return ConfElem(); },
+
+            [](auto, double value) { return ConfElem(value); },
+            [](auto, long long value) { return ConfElem(value); },
+            [](auto, std::string const& value) { return ConfElem(value); },
+            [](auto, bool value) { return ConfElem(value); },
+
+            [](auto self, zia::api::ConfObject const& map) {
+                auto currentElem = ConfElem(ConfMap());
+                for (auto& v : map)
+                {
+                    currentElem.set_at(v.first, self(v.second.v));
+                }
+                return currentElem;
+            },
+
+            [](auto self, zia::api::ConfArray const& array) {
+                auto currentElem = ConfElem(ConfArray());
+
+                for (auto& v : array) {
+                    currentElem.push(self(v.v));
+                }
+                return currentElem;
+            });
+
+        for (auto const& basicvalue : conf)
+        {
+            jsonConfig.set_at(basicvalue.first, std::visit(visitor, basicvalue.second.v));
+        }
+        return jsonConfig;
+    }
+
+    std::string ConfElem::basicPrettify(const zia::api::ConfValue &conf) {
+        std::ostringstream os {};
+        int sp {0};
+
+        constexpr auto indent = [](int indent) -> std::string {
+            return std::string(static_cast<std::size_t>(indent), ' ');
+        };
+
+        auto pvisit = make_recursive_visitor<void>(
+            [&os] (auto, std::monostate) { },
+            [&os] (auto, long long value) { os << value; },
+            [&os] (auto, double value) { os << std::fixed << value; },
+            [&os] (auto, bool value) { os << std::boolalpha << value; },
+            [&os] (auto, const std::string & value) { os << value; },
+            [&os, &sp, &indent] (auto recurse, zia::api::ConfObject value) {
+                os << "{\n";
+                sp += 4;
+                for (auto&& v : value) {
+                    os << indent(sp) << std::quoted(v.first) <<  ": ";
+                    recurse(v.second.v);
+                    os << ",\n";
+                }
+                sp -= 4;
+                os << indent(sp) << "}";
+            },
+            [&os, &sp, &indent](auto recurse, zia::api::ConfArray value) {
+                os << "[\n";
+                sp += 4;
+                auto it = value.begin();
+                if (it != value.end())
+                {
+                    os << indent(sp);
+                    recurse(it->v);
+                }
+                for (auto end = value.end(); it != end; ++it) {
+                    os << ",\n" << indent(sp);
+                    recurse(it->v);
+                }
+                sp -= 4;
+                os << "\n" << indent(sp) << "]";
+            }
+        );
+
+        std::visit(pvisit, conf.v);
+        return os.str();
+
+    }
+
+    std::string ConfElem::prettify(const ConfElem &conf) {
+        std::ostringstream os {};
+        int sp {0};
+
+        constexpr auto indent = [](int indent) -> std::string {
+            return std::string(static_cast<std::size_t>(indent), ' ');
+        };
+
+        auto pvisit = make_recursive_visitor<void>(
+            [&os] (auto, std::monostate) { },
+            [&os] (auto, long long value) { os << value; },
+            [&os] (auto, double value) { os << std::fixed << value; },
+            [&os] (auto, bool value) { os << std::boolalpha << value; },
+            [&os] (auto, const std::string & value) { os << value; },
+            [&os, &sp, &indent] (auto recurse, const ConfMap::Sptr& map ) {
+                os << "{\n";
+                sp += 4;
+                for (auto&& v : map->elems) {
+                    os << indent(sp) << std::quoted(v.first) <<  ": ";
+                    recurse(v.second->getValue());
+                    os << ",\n";
+                }
+                sp -= 4;
+                os << indent(sp) << "}";
+            },
+            [&os, &sp, &indent] (auto recurse, const ConfArray::Sptr& array) {
+                std::cout << "FOUND ARRAY" << std::endl;
+                os << "[\n";
+                sp += 4;
+                auto it = array->elems.begin();
+                if (it != array->elems.end())
+                {
+                    os << indent(sp);
+                    recurse((*it)->getValue());
+                }
+                for (auto end = array->elems.end(); it != end; ++it) {
+                    os << ",\n" << indent(sp);
+                    recurse((*it)->getValue());
+                }
+                sp -= 4;
+                os << "\n" << indent(sp) << "]";
+            }
+        );
+        std::visit(pvisit, conf.getValue());
+        return os.str();
+    }
+
 }

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -20,11 +20,8 @@ namespace zia::apipp {
 
         auto visitor = make_recursive_visitor<ConfElem>(
             [](auto, std::monostate) { return ConfElem(); },
-
-            [](auto, double value) { return ConfElem(value); },
-            [](auto, long long value) { return ConfElem(value); },
+            [](auto, auto value) { return ConfElem(value); },
             [](auto, std::string const& value) { return ConfElem(value); },
-            [](auto, bool value) { return ConfElem(value); },
 
             [](auto self, zia::api::ConfObject const& map) {
                 auto currentElem = ConfElem(ConfMap());
@@ -130,10 +127,11 @@ namespace zia::apipp {
                     os << indent(sp) << std::quoted(it->first) <<  ": ";
                     recurse(it->second->getValue());
                     if (it != endSep)
-                        os << ",\n";
+                        os << ',';
+                    os << '\n';
                 }
                 sp -= 4;
-                os << '\n' << indent(sp) << "}";
+                os << indent(sp) << "}";
             }
             else if constexpr (std::is_same_v<T, ConfArray::Sptr>) {
                 os << '[';
@@ -146,17 +144,18 @@ namespace zia::apipp {
                     os << indent(sp);
                     recurse((*it)->getValue());
                     if (it != end - 1)
-                        os << ",\n";
+                        os << ',';
+                    os << '\n';
                 }
                 sp -= 4;
-                os << "\n" << indent(sp) << "]";
+                os << indent(sp) << "]";
             }
         });
         std::visit(pvisit, conf.getValue());
         return os;
     }
 
-    std::ostream &operator<<(std::ostream &os, zia::api::Conf &conf) {
+    std::ostream &operator<<(std::ostream &os, zia::api::Conf const &conf) {
         int sp {0};
 
         constexpr auto indent = [](int indent) -> std::string {
@@ -172,10 +171,11 @@ namespace zia::apipp {
                 os << indent(sp) << std::quoted(it->first) <<  ": ";
                 recurse(it->second.v);
                 if (it != endSep)
-                    os << ",\n";
+                    os << ',';
+                os << '\n';
             }
             sp -= 4;
-            os << '\n' << indent(sp) << "}";
+            os << indent(sp) << "}";
         };
 
         auto pvisit = make_recursive_visitor<void>(
@@ -195,10 +195,11 @@ namespace zia::apipp {
                     os << indent(sp);
                     recurse(it->v);
                     if (it != end - 1)
-                        os << ",\n";
+                        os << ',';
+                    os << '\n';
                 }
                 sp -= 4;
-                os << '\n' << indent(sp) << ']';
+                os << indent(sp) << ']';
             },
             mapPrettify
         );

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -14,41 +14,7 @@ namespace zia::apipp {
 
     ConfElem::~ConfElem() = default;
 
-    ConfElem ConfElem::fromBasicConfig(const zia::api::Conf &conf) {
-
-        auto jsonConfig = ConfElem(ConfMap());
-
-        auto visitor = make_recursive_visitor<ConfElem>(
-            [](auto, std::monostate) { return ConfElem(); },
-            [](auto, auto value) { return ConfElem(value); },
-            [](auto, std::string const& value) { return ConfElem(value); },
-
-            [](auto self, zia::api::ConfObject const& map) {
-                auto currentElem = ConfElem(ConfMap());
-                for (auto& v : map)
-                {
-                    currentElem.set_at(v.first, self(v.second.v));
-                }
-                return currentElem;
-            },
-
-            [](auto self, zia::api::ConfArray const& array) {
-                auto currentElem = ConfElem(ConfArray());
-
-                for (auto& v : array) {
-                    currentElem.push(self(v.v));
-                }
-                return currentElem;
-            });
-
-        for (auto const& basicvalue : conf)
-        {
-            jsonConfig.set_at(basicvalue.first, std::visit(visitor, basicvalue.second.v));
-        }
-        return jsonConfig;
-    }
-
-    zia::api::Conf ConfElem::toBasicConfig() {
+	zia::api::Conf ConfElem::toBasicConfig() {
         namespace wrapped = zia::api;
         zia::api::Conf basicConf {};
 
@@ -99,7 +65,7 @@ namespace zia::apipp {
     std::ostream &operator<<(std::ostream &os, zia::apipp::Conf const &conf) {
         int sp {0};
 
-        constexpr auto indent = [](int indent) -> std::string {
+        auto indent = [](int indent) -> std::string {
             return std::string(static_cast<std::size_t>(indent), ' ');
         };
 
@@ -158,7 +124,7 @@ namespace zia::apipp {
     std::ostream &operator<<(std::ostream &os, zia::api::Conf const &conf) {
         int sp {0};
 
-        constexpr auto indent = [](int indent) -> std::string {
+        auto indent = [](int indent) -> std::string {
             return std::string(static_cast<std::size_t>(indent), ' ');
         };
 

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -419,19 +419,46 @@ namespace zia::apipp {
             }
         }
 
+        /**
+         * Returns the inner variant object. (used for std::visit).
+         * @return Variant type with std::monostate, long long, double, std::string,
+         * boolean, ConfArray and ConfMap types.
+         */
         const Variant &getValue() const {
             return value;
         }
 
-
+        /**
+         * Convert a configuration object from the SZA api to SZA++ format.
+         * @param conf Basic Configuration from wrapped API.
+         * @return SZA++ Configuration object.
+         */
         static ConfElem fromBasicConfig(const zia::api::Conf &conf);
 
+        /**
+         * Convert a configuration object from SZA++ format to a Conf object from the SZA Api.
+         * Since the Conf type from SZA++ is a Variant and the one from SZA Api is a map with named values, when
+         * a ConfElem is not a map element, a field "data" is added at the root to store the real data.
+         * @return
+         */
         zia::api::Conf toBasicConfig();
     };
 
-    std::ostream& operator<<(std::ostream& os, ConfElem const& conf);
+    /**
+     * Serialize a SZA++ Configuration for display/testing purposes.
+     * @param os Output stream
+     * @param conf
+     * @return
+     */
+    std::ostream& operator<<(std::ostream& os, ConfElem const &conf);
 
-    std::ostream& operator<<(std::ostream& os, zia::api::Conf& conf);
+    /**
+     * Serialize a SZA Configuration for display/testing purposes.
+     * @param os Output stream
+     * @param conf An element of the configuration.
+     * @return
+     */
+    std::ostream& operator<<(std::ostream& os, zia::api::Conf const &conf);
 
     /**
      * Alias for long long.

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -193,7 +193,6 @@ namespace zia::apipp {
             return (*this)[index];
         }
 
-
         const ConfElem &get_at(const std::string &index) const {
             return (*this)[index];
         }

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -118,7 +118,7 @@ namespace zia::apipp {
                 var = std::make_shared<TElem>(std::forward<TElem>(value));
             };
 
-            template<typename T, typename U = TElem, std::enable_if_t<std::is_same_v<bool, T> >* = nullptr>
+            template<typename T, typename U = TElem, std::enable_if_t<std::is_same_v<bool, U> >* = nullptr>
             static void set_value(T &&value, Variant &var) {
                 var = value;
             };

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -427,11 +427,11 @@ namespace zia::apipp {
         static ConfElem fromBasicConfig(const zia::api::Conf &conf);
 
         zia::api::Conf toBasicConfig();
-
-        static std::string basicPrettify(const zia::api::Conf &conf);
-
-        static std::string prettify(const ConfElem &conf);
     };
+
+    std::ostream& operator<<(std::ostream& os, ConfElem const& conf);
+
+    std::ostream& operator<<(std::ostream& os, zia::api::Conf& conf);
 
     /**
      * Alias for long long.

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -426,7 +426,9 @@ namespace zia::apipp {
 
         static ConfElem fromBasicConfig(const zia::api::Conf &conf);
 
-        static std::string basicPrettify(const zia::api::ConfValue &conf);
+        zia::api::Conf toBasicConfig();
+
+        static std::string basicPrettify(const zia::api::Conf &conf);
 
         static std::string prettify(const ConfElem &conf);
     };

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -419,10 +419,16 @@ namespace zia::apipp {
             }
         }
 
-
-        static ConfElem fromBasicConfig(const zia::api::Conf &conf) {
-            return {};
+        const Variant &getValue() const {
+            return value;
         }
+
+
+        static ConfElem fromBasicConfig(const zia::api::Conf &conf);
+
+        static std::string basicPrettify(const zia::api::ConfValue &conf);
+
+        static std::string prettify(const ConfElem &conf);
     };
 
     /**

--- a/api/pp/visitor.hpp
+++ b/api/pp/visitor.hpp
@@ -1,0 +1,60 @@
+//
+// basic_conf.tcc for sza_plus_plus in /home/anthony/repository/sza_plus_plus/basic_conf.tcc
+//
+// Made by Anthony LECLERC
+// Login   <anthony.leclerc@epitech.eu>
+//
+// Started on  mer. févr. 14 18:22:55 2018 Anthony LECLERC
+// Last update mer. févr. 14 18:22:55 2018 Anthony LECLERC
+//
+
+#ifndef SZA_PLUS_PLUS_BASIC_CONF_TCC
+#define SZA_PLUS_PLUS_BASIC_CONF_TCC
+
+/// Y-Combinator to allow infinite-recursion with lambdas.
+/// The lambda passed as parameter must take an `auto` as first parameter, which is the current
+/// function called. It allows recursion in lambdas sinc lambdas cannot be self-referenced in their scope.
+template<typename F>
+struct fix {
+public:
+    fix(F function) : _function(function) {}
+    fix(fix const&) = default;
+    fix(fix&&) = default;
+
+    template<typename ...Args>
+    decltype(auto) operator()(Args&& ...args) {
+        return _function(*this, std::forward<Args>(args)...);
+    }
+private:
+    F _function;
+};
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+template<typename TVisitor, typename TVariant>
+auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
+    return std::visit(
+        std::forward<TVisitor>(visitor),
+        std::forward<TVariant>(variant)
+    );
+
+};
+
+template<typename TReturn, typename ...TVisitors>
+auto make_recursive_visitor(TVisitors&& ...visitors)
+{
+    return fix([&visitors...](auto self, auto&& arg) -> TReturn {
+
+        return overloaded { std::forward<TVisitors>(visitors)... } (
+            [&self](auto&& v)
+            {
+                return recursive_visit(self, v);
+            },
+            std::forward<decltype(arg)>(arg)
+        );
+
+    });
+}
+
+#endif /* SZA_PLUS_PLUS_BASIC_CONF_TCC */

--- a/api/pp/visitor.hpp
+++ b/api/pp/visitor.hpp
@@ -18,73 +18,50 @@ private:
     F _function;
 };
 
+namespace detail {
 
-namespace lambda_util {
+    template <typename... lambda_ts>
+    struct composer_t;
 
-	namespace detail {
+    template <typename lambda_t>
+    struct composer_t<lambda_t> : lambda_t {
+        composer_t(const lambda_t& lambda) : lambda_t{ lambda } { }
+        composer_t(lambda_t&& lambda) : lambda_t{ std::move(lambda) } { }
 
-		template <typename... lambda_ts>
-		struct composer_t;
+        using lambda_t::operator();
+    };
 
-		template <typename lambda_t>
-		struct composer_t<lambda_t> : lambda_t {
-			composer_t(const lambda_t& lambda) : lambda_t{ lambda } { }
-			composer_t(lambda_t&& lambda) : lambda_t{ std::move(lambda) } { }
+    template <typename lambda_t, typename... more_lambda_ts>
+    struct composer_t<lambda_t, more_lambda_ts...> : lambda_t, composer_t<more_lambda_ts...> {
+        using super_t = composer_t<more_lambda_ts...>;
 
-			using lambda_t::operator();
-		};
+        template <typename... lambda_ts>
+        composer_t(const lambda_t& lambda, lambda_ts&&... more_lambdas) : lambda_t{ lambda }, super_t{ std::forward<lambda_ts>(more_lambdas)... } { }
+        template <typename... lambda_ts>
+        composer_t(lambda_t&& lambda, lambda_ts&&... more_lambdas) : lambda_t{ std::move(lambda) }, super_t{ std::forward<lambda_ts>(more_lambdas)... } { }
 
-		template <typename lambda_t, typename... more_lambda_ts>
-		struct composer_t<lambda_t, more_lambda_ts...> : lambda_t, composer_t<more_lambda_ts...> {
-			using super_t = composer_t<more_lambda_ts...>;
+        using lambda_t::operator();
+        using super_t::operator();
+    };
 
-			template <typename... lambda_ts>
-			composer_t(const lambda_t& lambda, lambda_ts&&... more_lambdas) : lambda_t{ lambda }, super_t{ std::forward<lambda_ts>(more_lambdas)... } { }
-			template <typename... lambda_ts>
-			composer_t(lambda_t&& lambda, lambda_ts&&... more_lambdas) : lambda_t{ std::move(lambda) }, super_t{ std::forward<lambda_ts>(more_lambdas)... } { }
-
-			using lambda_t::operator();
-			using super_t::operator();
-		};
-
-	} // namespace detail
-
-	template <typename... lambda_ts>
-	auto compose(lambda_ts&&... lambdas) {
-		return detail::composer_t<std::decay_t<lambda_ts>...>{std::forward<lambda_ts>(lambdas)...};
-	}
-
-} // namespace lambda_util
+    template <typename... lambda_ts>
+    auto compose(lambda_ts&&... lambdas) {
+        return detail::composer_t<std::decay_t<lambda_ts>...>{std::forward<lambda_ts>(lambdas)...};
+    }
+} // namespace detail
 
 
-template<typename ...Ts>
-struct overloaded;
-
-template<typename T>
-struct overloaded<T> {
-private:
-	T _f;
-public:
-	overloaded(T&& f) : _f(std::forward<T>(f)) {}
-
-	template<typename ...Args>
-	decltype(auto) operator()(Args&& ...args) {
-		return _f(std::forward<Args>(args)...);
-	}
-};
-
-template<typename T, typename ...Ts>
-struct overloaded<T, Ts...> : overloaded<T>, overloaded<Ts...> {
-public:
-
-	overloaded(T&& f, Ts&& ...fs) : overloaded<T>(std::forward<T>(f)),
-		overloaded<Ts...>(std::forward<Ts>(fs)...)
-	{}
-
-	using overloaded<T>::operator();
-	using overloaded<Ts...>::operator();
-
-};
+/// Doesn't work on MSVC since it doesn't support
+/// parameter-pack expansion for using-declarations yet.
+/*
+* template<typename ...Ts>
+* struct overloaded : Ts... {
+*    using overloaded<Ts>::operator()...;
+* };
+*
+* template<typename ...Ts>
+* overloaded(Ts...) -> overloaded<Ts...>;
+*/
 
 template<typename TVisitor, typename TVariant>
 constexpr auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
@@ -92,14 +69,22 @@ constexpr auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
         std::forward<TVisitor>(visitor),
         std::forward<TVariant>(variant)
     );
-
 };
 
+/**
+ * Used to make a recusive visitor to give to std::visit.
+ * Function passed as parameter must have an 'auto' as first parameter
+ * to take the visitor object which is used to continue recursion.
+ * @tparam TReturn Return type of visitors object given as parameter.
+ * The return type must be explicit since the selfRecursion cannot deduct self return type.
+ * @tparam TVisitors Callable objects taking as parameter a generic function type
+ * and as second parameter one of the types stored in the variant visited.
+ */
 template<typename TReturn, typename ...TVisitors>
 constexpr auto make_recursive_visitor(TVisitors&& ...visitors) {
 	auto selfRecursion = [&visitors...](auto self, auto&& arg)->TReturn {
 
-		return lambda_util::compose ( std::forward<TVisitors>(visitors)... ) (
+		return detail::compose ( std::forward<TVisitors>(visitors)... ) (
 			[&self](auto&& v)
 		{
 			return recursive_visit(self, v);

--- a/api/pp/visitor.hpp
+++ b/api/pp/visitor.hpp
@@ -17,12 +17,12 @@
 template<typename F>
 struct fix {
 public:
-    fix(F function) : _function(function) {}
+    constexpr fix(F function) : _function(function) {}
     fix(fix const&) = default;
     fix(fix&&) = default;
 
     template<typename ...Args>
-    decltype(auto) operator()(Args&& ...args) {
+    constexpr decltype(auto) operator()(Args&& ...args) {
         return _function(*this, std::forward<Args>(args)...);
     }
 private:
@@ -33,7 +33,7 @@ template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 template<typename TVisitor, typename TVariant>
-auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
+constexpr auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
     return std::visit(
         std::forward<TVisitor>(visitor),
         std::forward<TVariant>(variant)
@@ -42,7 +42,7 @@ auto recursive_visit(TVisitor&& visitor, TVariant&& variant) {
 };
 
 template<typename TReturn, typename ...TVisitors>
-auto make_recursive_visitor(TVisitors&& ...visitors)
+constexpr auto make_recursive_visitor(TVisitors&& ...visitors)
 {
     return fix([&visitors...](auto self, auto&& arg) -> TReturn {
 


### PR DESCRIPTION
### Added
- **fromBasicConfig() implementation**: static method for zia::api::Conf to zia::apipp::Conf conversion.

- **toBasicConfig() implementation** : method for zia::apipp::Conf to zia::api::Conf conversion.
_Note_: Since zia::api::Conf is a map with named value, **if** the current ConfElem object is **not** a map type, a "_data_" field is added at the root of the created basic Conf object.
- **Recursive visitor** : A function taking lambdas as parameters and returning a new function to give as first argument of **std::visit()**. It allows easier and safer iteration over Conf objects.
Every overload must be generated, else errors like this will occur (here with std::monostate overload missing):
> cannot convert ‘std::forward<<std::monostate&>>((* & arg))’ (type ‘std::monostate’) to type ‘long long int’.
...

and with every other type in the variant. There are more examples of uses in _Test3.cpp_.
If some errors persist, it is maybe necessary to implement the visitor functions as one with
**if constexpr** conditions to test the correct type (see _fromBasicConfig()_ implementation) instead of different functions.

- **Serialization** of zia::api::Conf and zia::apipp::Conf to standard streams with their operator. Call any configuration object like :
> ConfElem conf;
... fill elements ...
std::cout << config << std::endl;

and it will print a prettified version of the element.
It is also JSON compliant.

Tested on g++-7 and MSVC 14.2 with Visual Studio 15.5.2