### PR TITLE
Added Conf::visit() method for std::visit() encapsulation.

### DIFF
--- a/Test3.cpp
+++ b/Test3.cpp
@@ -113,15 +113,15 @@ void test3() {
 
 
         zia::api::ConfValue valueArray;
-        valueArray.v = std::vector<zia::api::ConfValue> { valueBool, valueString, valueLong, valueDouble };
+        valueArray.v = std::vector<zia::api::ConfValue> {valueBool, valueString, valueLong, valueDouble};
 
         zia::api::ConfObject valueMap;
         valueMap = std::map<std::string, zia::api::ConfValue> {
-            {"first", valueArray},
+            {"first",  valueArray},
             {"second", valueBool},
-            {"third", valueLong},
+            {"third",  valueLong},
             {"fourth", valueString},
-            {"fifth", valueDouble}
+            {"fifth",  valueDouble}
         };
         zia::api::Conf root = valueMap;
 
@@ -140,21 +140,43 @@ void test3() {
         std::cout << "TEST -- Visit of Conf element" << std::endl;
         auto testVisitor = make_recursive_visitor<void>(
             [](auto, std::monostate) { std::cout << "Empty" << std::endl; },
-            [](auto, std::string const&) { std::cout << "String" << std::endl; },
+            [](auto, std::string const &) { std::cout << "String" << std::endl; },
             [](auto, long long int) { std::cout << "Long" << std::endl; },
-            [](auto, double) { std::cout << "Double" << std::endl;} ,
+            [](auto, double) { std::cout << "Double" << std::endl; },
             [](auto, bool) { std::cout << "Bool" << std::endl; },
-            [](auto recurse, ConfArray::Sptr const& array) { std::cout << "Array" << std::endl;
-                for (auto&& v : array->elems) {
+            [](auto recurse, ConfArray::Sptr const &array) {
+                std::cout << "Array" << std::endl;
+                for (auto &&v : array->elems) {
                     recurse(v->getValue());
                 }
             },
-            [](auto recurse, ConfMap::Sptr const& map) { std::cout << "Map" << std::endl;
-            for (auto&& v : map->elems) {
-                recurse(v.second->getValue());
-            }}
+            [](auto recurse, ConfMap::Sptr const &map) {
+                std::cout << "Map" << std::endl;
+                for (auto &&v : map->elems) {
+                    recurse(v.second->getValue());
+                }
+            }
         );
 
         std::visit(testVisitor, wrappedConfig.getValue());
+
+        wrappedConfig.visit(
+            [](auto, std::monostate) { std::cout << "Empty" << std::endl; },
+            [](auto, std::string const &) { std::cout << "String" << std::endl; },
+            [](auto, long long int) { std::cout << "Long" << std::endl; },
+            [](auto, double) { std::cout << "Double" << std::endl; },
+            [](auto, bool) { std::cout << "Bool" << std::endl; },
+            [](auto recurse, ConfArray::Sptr const &array) {
+                std::cout << "Array" << std::endl;
+                for (auto &&v : array->elems) {
+                    recurse(v->getValue());
+                }
+            },
+            [](auto recurse, ConfMap::Sptr const &map) {
+                std::cout << "Map" << std::endl;
+                for (auto &&v : map->elems) {
+                    recurse(v.second->getValue());
+                }
+            });
     }
 }

--- a/Test3.cpp
+++ b/Test3.cpp
@@ -136,8 +136,9 @@ void test3() {
         /// Visitor used to iterate over the configuration.
         /// Use this instead of chaining "get<T>()" calls with try/catch.
         /// The first argument is the "self" lambda. Call it to continue recursion.
-        /// TODO: visit method in Conf for easier manipulation.
         std::cout << "TEST -- Visit of Conf element" << std::endl;
+
+        /// Without encapsulated visit.
         auto testVisitor = make_recursive_visitor<void>(
             [](auto, std::monostate) { std::cout << "Empty" << std::endl; },
             [](auto, std::string const &) { std::cout << "String" << std::endl; },
@@ -160,6 +161,7 @@ void test3() {
 
         std::visit(testVisitor, wrappedConfig.getValue());
 
+        /// With encapsulated visit. void is the default return type.
         wrappedConfig.visit(
             [](auto, std::monostate) { std::cout << "Empty" << std::endl; },
             [](auto, std::string const &) { std::cout << "String" << std::endl; },

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -17,7 +17,7 @@ namespace zia::apipp {
 	zia::api::Conf ConfElem::toBasicConfig() {
         namespace wrapped = zia::api;
         zia::api::Conf basicConf {};
-
+        
         auto pvisit = make_recursive_visitor<wrapped::ConfValue>(
             [](auto, std::monostate) { return wrapped::ConfValue(); },
             [](auto, auto value) {

--- a/api/pp/conf.cpp
+++ b/api/pp/conf.cpp
@@ -17,8 +17,8 @@ namespace zia::apipp {
 	zia::api::Conf ConfElem::toBasicConfig() {
         namespace wrapped = zia::api;
         zia::api::Conf basicConf {};
-        
-        auto pvisit = make_recursive_visitor<wrapped::ConfValue>(
+
+        auto root = visit<wrapped::ConfValue>(
             [](auto, std::monostate) { return wrapped::ConfValue(); },
             [](auto, auto value) {
                 auto v = wrapped::ConfValue();
@@ -39,7 +39,7 @@ namespace zia::apipp {
                 wrapped::ConfValue value;
                 value.v = basicarray;
                 return value;
-            },
+                                                          },
             [](auto recurse, ConfMap::Sptr const& map) {
                 wrapped::ConfObject basicmap {};
 
@@ -50,10 +50,8 @@ namespace zia::apipp {
                 wrapped::ConfValue value;
                 value.v = basicmap;
                 return value;
-            }
-        );
+            });
 
-        auto root = std::visit(pvisit, value);
         if (type == Map) {
             return std::get<wrapped::ConfObject>(root.v);
         }
@@ -69,7 +67,7 @@ namespace zia::apipp {
             return std::string(static_cast<std::size_t>(indent), ' ');
         };
 
-        auto pvisit = make_recursive_visitor<void>( [&os, &sp, &indent](auto recurse, auto&& value) {
+        conf.visit<void>([&os, &sp, &indent](auto recurse, auto&& value) {
             using T = std::decay_t<decltype(value)>;
             if constexpr (std::is_same_v<T, std::monostate>) {}
             else if constexpr (std::is_same_v<T, long long>) {
@@ -117,7 +115,6 @@ namespace zia::apipp {
                 os << indent(sp) << "]";
             }
         });
-        std::visit(pvisit, conf.getValue());
         return os;
     }
 

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -438,6 +438,15 @@ namespace zia::apipp {
             return value;
         }
 
+        template<typename TReturn = void, typename ...TVisitors>
+        decltype(auto) visit(TVisitors&& ...visitors) {
+            auto rec_visit = make_recursive_visitor<TReturn>(
+                std::forward<TVisitors>(visitors)...
+            );
+
+            return std::visit(rec_visit, getValue());
+        };
+
         /**
          * Convert a configuration object from the SZA api to SZA++ format.
          * @param conf Basic Configuration from wrapped API.
@@ -447,7 +456,7 @@ namespace zia::apipp {
 			auto jsonConfig = ConfElem(ConfMap());
 
 			auto visitor = make_recursive_visitor<ConfElem>([](auto self, auto&& value) -> ConfElem {
-				using T = std::decay_t<decltype(value)>;
+                using T = std::decay_t<decltype(value)>;
 
 				if constexpr (std::is_same_v<T, std::monostate>) {
 					return ConfElem();

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -1,7 +1,5 @@
 
-//#pragma once
-#ifndef CONF_HPP
-#define CONF_HPP
+#pragma once
 
 #include <iostream>
 #include <memory>
@@ -438,8 +436,16 @@ namespace zia::apipp {
             return value;
         }
 
+        /**
+         * Encapsulated std::visit call with a recursive visitor.
+         * @tparam TReturn default return type is void, must be given explicitly otherwise.
+         * @tparam TVisitors Every overload must be given. Either with functions of different arguments type,
+         * or a function with a generic parameter, and type selection with if constexpr expressions.
+         * @param visitors
+         * @return TReturn
+         */
         template<typename TReturn = void, typename ...TVisitors>
-        decltype(auto) visit(TVisitors&& ...visitors) {
+        decltype(auto) visit(TVisitors&& ...visitors) const {
             auto rec_visit = make_recursive_visitor<TReturn>(
                 std::forward<TVisitors>(visitors)...
             );
@@ -540,4 +546,3 @@ namespace zia::apipp {
 
     using Conf = ConfElem;
 }
-#endif

--- a/api/pp/visitor.hpp
+++ b/api/pp/visitor.hpp
@@ -86,11 +86,11 @@ constexpr auto make_recursive_visitor(TVisitors&& ...visitors) {
 
 		return detail::compose ( std::forward<TVisitors>(visitors)... ) (
 			[&self](auto&& v)
-		{
-			return recursive_visit(self, v);
-		},
-			std::forward<decltype(arg)>(arg)
-			);
-	};
+            {
+                return recursive_visit(self, v);
+            },
+            std::forward<decltype(arg)>(arg)
+        );
+    };
     return fix<decltype(selfRecursion)>(selfRecursion);
 }


### PR DESCRIPTION
- **Conf::visit()** allows a visit in 1 call instead of creating a visitor with **make_recursive_visitor()** and calling **std::visit()** afterwards.
Every overload must be given, but a function with a generic argument can replace every overload for primitive type if the implementation is the same.

Return type of visit() is defaulted to void, but it must be given explicitly if visitors returns something 
(every visitor must return the same thing).

Tested with g++-7 , Visual Studio 15.5 and MSVC 14.12