### PR TITLE
Removed 'explicit' constructor in Conf.

### DIFF
--- a/Test3.cpp
+++ b/Test3.cpp
@@ -9,18 +9,21 @@ using namespace std::literals::string_literals;
 
 using namespace zia::apipp;
 void test3() {
+
+    /// Don't need ConfElem explicit constructor call when setting values,
+    /// But still need it when manipulating values afterwards (for ConfMap and
+    /// ConfArray for example).
     auto conf = ConfElem()
         .set(ConfMap())
-        .set_at("string_test", ConfElem().set("first_value"s))
-        .set_at("integer_test", ConfElem().set(42))
-        .set_at("double_test", ConfElem().set(42.42))
-        .set_at("nested_map_test", ConfElem()
-            .set(ConfMap())
-            .set_at("op", ConfElem().set(1)))
+        .set_at("string_test", "first_value"s)
+        .set_at("integer_test", 42)
+        .set_at("double_test", 42.42)
+        .set_at("nested_map_test", ConfElem(ConfMap())
+            .set_at("op", 1))
         .set_at("array_test",
-                ConfElem().set(ConfArray())
-                    .push(ConfElem().set(true))
-                    .push(ConfElem().set(false)));
+                ConfElem(ConfArray())
+                    .push(true)
+                    .push(false));
 
     std::cout << conf.get_at("string_test").get<std::string>() << std::endl;
     std::cout << conf.get_at("integer_test").get<int>() << std::endl;
@@ -34,6 +37,8 @@ void test3() {
     std::cout << conf.get_at("array_test").get_at(1).get<bool>() << std::endl;
 
     std::cout << conf["array_test"][0].get<bool>() << std::endl;
+
+    std::cout << conf << std::endl;
 
     /// Test with copy
     {
@@ -52,7 +57,7 @@ void test3() {
         /// Copy a previous config object but doesn't keep references.
         auto conf2 = conf;
         conf2.set(ConfMap()).set_at("data", conf3);
-        conf2.set_at("string_test", ConfElem().set("in_copied_map."s));
+        conf2.set_at("string_test", "in_copied_map."s);
 
         conf4->set("new_value"s);
 
@@ -85,7 +90,7 @@ void test3() {
         std::cout << "ConfDouble Type: " << confDouble->getType() << std::endl;
 
         confArray->push(confString);
-        confArray->push(ConfElem("titi"s));
+        confArray->push("titi"s);
 
         auto conf2 = ConfElem().set(ConfMap()).set_at("data", confArray);
         confString->set("new_value"s);
@@ -93,8 +98,8 @@ void test3() {
         std::cout << conf2.get_at("data").get_at(0).get<std::string>() << std::endl;
         std::cout << conf2.get_at("data").get_at(1).get<std::string>() << std::endl;
 
-        confMap->set_at("first", ConfElem("Value1"s));
-        confMap->set_at("second", ConfElem("Value2"s));
+        confMap->set_at("first", "Value1"s);
+        confMap->set_at("second", "Value2"s);
 
         conf2.set_at("data", confMap);
         std::cout << conf2.get_at("data").get_at("first").get<std::string>() << std::endl;

--- a/api/pp/conf.hpp
+++ b/api/pp/conf.hpp
@@ -157,7 +157,7 @@ namespace zia::apipp {
          */
 
         template<typename T, std::enable_if_t<!isThisType<T, ConfElem>()> * = nullptr>
-        explicit ConfElem(T&& v) : type(variant_helper<std::decay_t<T>>::get_type()), value() {
+        ConfElem(T&& v) : type(variant_helper<std::decay_t<T>>::get_type()), value() {
             variant_helper<std::decay_t<T> >::set_value(std::forward<T>(v), value);
         }
 


### PR DESCRIPTION
Remove **'explicit'** for Conf constructor helper to allow building values without calling Conf constructor everytime.

- Before:
`Conf(ConfMap()).set_at("key", Conf("value"s));`
`Conf(ConfArray()).push(Conf("value"));`
- Now:
`Conf(ConfMap()).set_at("string_test", "value"s);`
`Conf(ConfArray()).push("value"s);`

Arrays and Map still need to be constructed explicitly with Conf to get access to methods set_at/push, but  it's possible to build empty arrays and map implicitly:
`Conf conf = ConfMap();``
`conf.set_at("key", ConfArray());`
